### PR TITLE
7-Convert-to-Grayscale

### DIFF
--- a/src/determine_transformation.py
+++ b/src/determine_transformation.py
@@ -1,6 +1,7 @@
 import argparse
 import numpy
 from PIL import Image
+from PIL import ImageOps
 from PIL import UnidentifiedImageError
 import TransformationCalculator
 
@@ -9,15 +10,16 @@ def loadImage(filename: str) -> numpy.ndarray:
     """!
     @brief Load an image from file to return as a numpy array.
 
-    This uses Pillow as an intermediary to support loading a variety of image formats. After, it simply converts to a
-    numpy array to use by the user.
+    This uses Pillow as an intermediary to support loading a variety of image formats. After, it converts the image to
+    grayscale and returns it as a numpy array.
     @param filename The file to load.
-    @return numpy.ndarray A numpy array of the loaded image.
+    @return numpy.ndarray A numpy array of the grayscale version of the loaded image.
     @throws FileNotFoundError Thrown if the file does not exist.
     @throws PIL.UnidentifiedImageError Thrown if the image cannot be read.
     """
     image = Image.open(filename)
-    image_array = numpy.array(image)
+    grayscale_image = ImageOps.grayscale(image)
+    image_array = numpy.array(grayscale_image)
     return image_array
 
 

--- a/src/test_determine_transformation.py
+++ b/src/test_determine_transformation.py
@@ -9,6 +9,14 @@ class TestFileInput(unittest.TestCase):
     @brief Test the ability to read image files.
     """
 
+    def test_bad_file(self):
+        """!
+        @test Test that the function throws correctly when unable to open a file.
+        """
+        # Load some other non-image file.
+        self.assertRaises(UnidentifiedImageError,
+                          determine_transformation.loadImage, 'data/000000.txt')
+
     def test_good_file(self):
         """!
         @test Test that the function can read in valid image files.
@@ -17,13 +25,13 @@ class TestFileInput(unittest.TestCase):
         self.assertIsInstance(
             result, ndarray, 'Returned image is not a numpy array.')
 
-    def test_bad_file(self):
+    def test_grayscale(self):
         """!
-        @test Test that the function throws correctly when unable to open a file.
+        @test Test that returned images only have one channel.
         """
-        # Load some other non-image file.
-        self.assertRaises(UnidentifiedImageError,
-                          determine_transformation.loadImage, 'data/000000.txt')
+        result = determine_transformation.loadImage('data/000000.png')
+        self.assertEqual(len(result.shape), 2,
+                         'Returned image has multiple channels.')
 
     def test_no_file(self):
         """!


### PR DESCRIPTION
This pull request adds a call to PIL's grayscale conversion function prior to passing the image into the transform library. This will ensure all images are a single channel. I decided to do this prior to the library so that the library can focus purely on the actual feature detection process, instead of image manipulation as well.

Closes #7 