### PR TITLE
19-Correct-Transform

### DIFF
--- a/evaluation/Evaluator.py
+++ b/evaluation/Evaluator.py
@@ -125,7 +125,7 @@ class Evaluator:
             H, intrinsic)
         # Find the correct one by comparision of the normals to identity
         normal_cos_angles = numpy.zeros((num_solutions, 1))
-        unit_vector = numpy.array([0.0, 0.0, -1.0])
+        unit_vector = numpy.array([0.0, 0.0, 1.0])
         for i in range(num_solutions):
             # The normal vector should already be normalized, so no need to normalize.
             normal_cos_angles[i] = numpy.dot(normals[i].squeeze(), unit_vector)

--- a/evaluation/Evaluator.py
+++ b/evaluation/Evaluator.py
@@ -123,19 +123,17 @@ class Evaluator:
         # Determine candidate transformations
         num_solutions, rotations, translations, normals = cv2.decomposeHomographyMat(
             H, intrinsic)
+        # Find the correct one by comparision of the normals to identity
+        normal_cos_angles = numpy.zeros((num_solutions, 1))
+        unit_vector = numpy.array([0.0, 0.0, -1.0])
         for i in range(num_solutions):
-            print('Solution #{0:d}'.format(i))
-            print('Rotation:')
-            print(rotations[i])
-            print('Translation:')
-            print(translations[i])
-            print('Normal:')
-            print(normals[i])
-            print('\n############################\n')
-        # Find the correct one by knowledge of the data collection
+            # The normal vector should already be normalized, so no need to normalize.
+            normal_cos_angles[i] = numpy.dot(normals[i].squeeze(), unit_vector)
+        # The right one to pick is whichever is the cos(angle) closest to 1 AKA most aligned.
+        selection = numpy.argmax(normal_cos_angles)
         transformation = numpy.eye(4)
-        transformation[0:3, 0:3] = rotations[0]
-        transformation[0:3, 3:] = translations[0]
+        transformation[0:3, 0:3] = rotations[selection]
+        transformation[0:3, 3:] = translations[selection]
         return transformation
 
     def _findCorrespondence(self, first_keypoints: List[cv2.KeyPoint], first_descriptors: numpy.ndarray, second_keypoints: List[cv2.KeyPoint], second_descriptors: numpy.ndarray) -> Tuple[numpy.ndarray, numpy.ndarray]:

--- a/evaluation/Evaluator.py
+++ b/evaluation/Evaluator.py
@@ -123,6 +123,15 @@ class Evaluator:
         # Determine candidate transformations
         num_solutions, rotations, translations, normals = cv2.decomposeHomographyMat(
             H, intrinsic)
+        for i in range(num_solutions):
+            print('Solution #{0:d}'.format(i))
+            print('Rotation:')
+            print(rotations[i])
+            print('Translation:')
+            print(translations[i])
+            print('Normal:')
+            print(normals[i])
+            print('\n############################\n')
         # Find the correct one by knowledge of the data collection
         transformation = numpy.eye(4)
         transformation[0:3, 0:3] = rotations[0]

--- a/evaluation/tests/test_Evaluator.py
+++ b/evaluation/tests/test_Evaluator.py
@@ -63,11 +63,11 @@ class TestEvaluator(unittest.TestCase):
         first_points = numpy.array(
             [[0, 0, z], [2, 0, z], [2, 5, z], [0, 5, z]], dtype=numpy.float32)
         # Create a transformation that will move the camera
-        R = numpy.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-        t = numpy.array([[3.0], [0.0], [0.0]])
+        R = numpy.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        t = numpy.array([[3.0], [-5.0], [0.0]])
         expected_result = numpy.eye(4)
-        expected_result[0:3, 0:3] = R.transpose()
-        expected_result[0:3, 3:] = numpy.matmul(R.transpose(), -t)
+        expected_result[0:3, 0:3] = R
+        expected_result[0:3, 3:] = t
         # Determine where the second points would be given that.
         second_points = (numpy.matmul(
             R, first_points.transpose()) + t).transpose()
@@ -94,7 +94,7 @@ class TestEvaluator(unittest.TestCase):
                 result_element = result[i, j]
                 expected_element = expected_result[i, j]
                 self.assertAlmostEqual(result_element, expected_element, 6,
-                                       'Matrix element ({0:d}, {1:d} is incorrect.'.format(i, j))
+                                       'Matrix element ({0:d}, {1:d}) is incorrect.'.format(i, j))
 
     def testCalculateTranslationDiff(self):
         """!


### PR DESCRIPTION
This adds the correct way to select a transform after homography decomposition. I'm still not positive if it needs to be this or the inverse, but the numbers seem to suggest the one returned. To calculate, it finds the one closes to the unit Z vector, since the ground plane is assumed to lie flat in the XY plane.

Closes #19 